### PR TITLE
Azure SDK in AppInsights SDK: Set Http and EventHubs properties

### DIFF
--- a/WEB/Src/Common/PropertyFetcher.cs
+++ b/WEB/Src/Common/PropertyFetcher.cs
@@ -22,7 +22,7 @@
         {
             if (this.innerFetcher == null)
             {
-                this.innerFetcher = PropertyFetch.FetcherForProperty(obj.GetType().GetTypeInfo().GetDeclaredProperty(this.propertyName));
+                this.innerFetcher = PropertyFetch.FetcherForProperty(obj?.GetType()?.GetTypeInfo()?.GetDeclaredProperty(this.propertyName));
             }
 
             return this.innerFetcher?.Fetch(obj);

--- a/WEB/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/WEB/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -28,6 +28,9 @@
     <RootNamespace>Microsoft.ApplicationInsights.DependencyCollector</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/WEB/Src/DependencyCollector/Net45.Tests/app.config
+++ b/WEB/Src/DependencyCollector/Net45.Tests/app.config
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0"/>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/WEB/Src/DependencyCollector/Net45.Tests/packages.config
+++ b/WEB/Src/DependencyCollector/Net45.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net451" developmentDependency="true" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net451" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net451" />

--- a/WEB/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
+++ b/WEB/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using System.Threading.Tasks;
+    using System.Net.Http;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -12,6 +12,7 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Web.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
 
     [TestClass]
     public class AzureSdkDiagnosticListenerTest
@@ -75,6 +76,7 @@
 
                 Assert.IsNotNull(telemetry);
                 Assert.AreEqual("SomeClient.Send", telemetry.Name);
+                Assert.AreEqual("InProc", telemetry.Type);
                 Assert.IsTrue(telemetry.Success.Value);
 
                 Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
@@ -82,10 +84,123 @@
                 Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
-                Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["property"]);
-
+                
                 Assert.IsTrue(telemetry.Properties.TryGetValue("tracestate", out var tracestate));
                 Assert.AreEqual("state=some", tracestate);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedClientKind()
+        {
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity sendActivity = new Activity("Azure.SomeClient.Send");
+                sendActivity.AddTag("kind", "client");
+
+                listener.StartActivity(sendActivity, null);
+                listener.StopActivity(sendActivity, null);
+
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("SomeClient.Send", telemetry.Name);
+                Assert.AreEqual(string.Empty, telemetry.Type);
+                Assert.IsTrue(telemetry.Success.Value);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedServerKind()
+        {
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity sendActivity = new Activity("Azure.SomeClient.Send");
+                sendActivity.AddTag("kind", "server");
+
+                listener.StartActivity(sendActivity, null);
+                listener.StopActivity(sendActivity, null);
+
+                var telemetry = this.sentItems.Last() as RequestTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("SomeClient.Send", telemetry.Name);
+                Assert.IsTrue(telemetry.Success.Value);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedLinks()
+        {
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                var sendActivity = new Activity("Azure.SomeClient.Send");
+                var link0TraceId = "70545f717a9aa6a490d820438b9d2bf6";
+                var link1TraceId = "c5aa06717eef0c4592af26323ade92f7";
+                var link0SpanId = "8b0b2fb40c84e64a";
+                var link1SpanId = "3a69ce690411bb4f";
+
+                var payload = new PayloadWithLinks
+                {
+                    Links = new List<Activity>
+                    {
+                        new Activity("link0").SetParentId($"00-{link0TraceId}-{link0SpanId}-01"),
+                        new Activity("link1").SetParentId($"00-{link1TraceId}-{link1SpanId}-01"),
+                    },
+                };
+
+                listener.StartActivity(sendActivity, payload);
+                listener.StopActivity(sendActivity, null);
+
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("SomeClient.Send", telemetry.Name);
+                Assert.IsTrue(telemetry.Success.Value);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+
+                // does not throw
+                var jsonSettingThrowOnError = new JsonSerializerSettings
+                {
+                    MissingMemberHandling = MissingMemberHandling.Error,
+                    ReferenceLoopHandling = ReferenceLoopHandling.Error,
+                    NullValueHandling = NullValueHandling.Include,
+                    DefaultValueHandling = DefaultValueHandling.Include,
+                };
+
+                Assert.IsTrue(telemetry.Properties.TryGetValue("_MS.links", out var linksStr));
+                var actualLinks = JsonConvert.DeserializeObject<ApplicationInsightsLink[]>(linksStr, jsonSettingThrowOnError);
+
+                Assert.IsNotNull(actualLinks);
+                Assert.AreEqual(2, actualLinks.Length);
+
+                Assert.AreEqual(link0TraceId, actualLinks[0].OperationId);
+                Assert.AreEqual(link1TraceId, actualLinks[1].OperationId);
+
+                Assert.AreEqual(link0SpanId, actualLinks[0].Id);
+                Assert.AreEqual(link1SpanId, actualLinks[1].Id);
+
+                Assert.AreEqual($"[{{\"operation_Id\":\"{link0TraceId}\",\"id\":\"{link0SpanId}\"}},{{\"operation_Id\":\"{link1TraceId}\",\"id\":\"{link1SpanId}\"}}]", linksStr);
             }
         }
 
@@ -113,13 +228,186 @@
                 Assert.IsNotNull(telemetry);
                 Assert.AreEqual("SomeClient.Send", telemetry.Name);
                 Assert.IsFalse(telemetry.Success.Value);
-                Assert.AreEqual(telemetry.Data, exception.ToInvariantString());
+
+                Assert.AreEqual(exception.ToInvariantString(), telemetry.Properties["Error"]);
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
                 Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
 
-                Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["property"]);
+        [TestMethod]
+        public void AzureClientSpansAreCollectedForHttp()
+        {
+            using (var listener = new DiagnosticListener("Azure.Core"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity httpActivity = new Activity("Azure.Core.Http.Request")
+                    .AddTag("http.method", "PATCH")
+                    .AddTag("http.url", "http://host:8080/path?query#fragment")
+                    .AddTag("requestId", "client-request-id");
+
+                var payload = new HttpRequestMessage();
+                listener.StartActivity(httpActivity, payload);
+                httpActivity
+                    .AddTag("http.status_code", "206")
+                    .AddTag("serviceRequestId", "service-request-id");
+
+                listener.StopActivity(httpActivity, payload);
+                
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("PATCH /path", telemetry.Name);
+                Assert.AreEqual("host:8080", telemetry.Target);
+                Assert.AreEqual("http://host:8080/path?query#fragment", telemetry.Data);
+                Assert.AreEqual("206", telemetry.ResultCode);
+                Assert.AreEqual("Http", telemetry.Type);
+                Assert.IsTrue(telemetry.Success.Value);
+                Assert.AreEqual("client-request-id", telemetry.Properties["ClientRequestId"]);
+                Assert.AreEqual("service-request-id", telemetry.Properties["ServerRequestId"]);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(httpActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{httpActivity.TraceId.ToHexString()}.{httpActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedForHttpNotSuccessResponse()
+        {
+            using (var listener = new DiagnosticListener("Azure.Core"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity httpActivity = new Activity("Azure.Core.Http.Request")
+                    .AddTag("http.method", "PATCH")
+                    .AddTag("http.url", "http://host/path?query#fragment");
+
+                var payload = new HttpRequestMessage();
+                listener.StartActivity(httpActivity, payload);
+                httpActivity.AddTag("http.status_code", "503");
+
+                listener.StopActivity(httpActivity, payload);
+
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("PATCH /path", telemetry.Name);
+                Assert.AreEqual("host", telemetry.Target);
+                Assert.AreEqual("http://host/path?query#fragment", telemetry.Data);
+                Assert.AreEqual("503", telemetry.ResultCode);
+                Assert.AreEqual("Http", telemetry.Type);
+                Assert.IsFalse(telemetry.Success.Value);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(httpActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{httpActivity.TraceId.ToHexString()}.{httpActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedForHttpException()
+        {
+            using (var listener = new DiagnosticListener("Azure.Core"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                var exception = new InvalidOperationException();
+                Activity httpActivity = new Activity("Azure.Core.Http.Request")
+                    .AddTag("http.method", "PATCH")
+                    .AddTag("http.url", "http://host/path?query#fragment");
+
+                listener.StartActivity(httpActivity, null);
+                listener.Write("Azure.SomeClient.Send.Exception", exception);
+
+                listener.StopActivity(httpActivity, null);
+
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("PATCH /path", telemetry.Name);
+                Assert.AreEqual("host", telemetry.Target);
+                Assert.AreEqual("http://host/path?query#fragment", telemetry.Data);
+                Assert.IsNull(telemetry.ResultCode);
+                Assert.AreEqual("Http", telemetry.Type);
+                Assert.IsFalse(telemetry.Success.Value);
+                Assert.AreEqual(exception.ToInvariantString(), telemetry.Properties["Error"]);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(httpActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{httpActivity.TraceId.ToHexString()}.{httpActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedForEventHubs()
+        {
+            using (var listener = new DiagnosticListener("Azure.Messaging.EventHubs"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                var exception = new InvalidOperationException();
+                Activity sendActivity = new Activity("Azure.Messaging.EventHubs.EventHubProducerClient.Send")
+                    .AddTag("peer.address", "amqps://eventHub.servicebus.windows.net/")
+                    .AddTag("message_bus.destination", "queueName")
+                    .AddTag("kind", "producer");
+
+                listener.StartActivity(sendActivity, null);
+                listener.Write("Azure.Messaging.EventHubs.EventHubProducerClient.Send.Exception", exception);
+                listener.StopActivity(sendActivity, null);
+
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("EventHubProducerClient.Send", telemetry.Name);
+                Assert.AreEqual("amqps://eventHub.servicebus.windows.net/ | queueName", telemetry.Target);
+                Assert.AreEqual(string.Empty, telemetry.Data);
+                Assert.AreEqual(string.Empty, telemetry.ResultCode);
+                Assert.AreEqual("Azure Event Hubs", telemetry.Type);
+                Assert.IsFalse(telemetry.Success.Value);
+                Assert.AreEqual(exception.ToInvariantString(), telemetry.Properties["Error"]);
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+            }
+        }
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedForEventHubsException()
+        {
+            using (var listener = new DiagnosticListener("Azure.Messaging.EventHubs"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity sendActivity = new Activity("Azure.Messaging.EventHubs.EventHubProducerClient.Send")
+                    .AddTag("peer.address", "amqps://eventHub.servicebus.windows.net/")
+                    .AddTag("message_bus.destination", "queueName")
+                    .AddTag("kind", "producer");
+
+                listener.StartActivity(sendActivity, null);
+                listener.StopActivity(sendActivity, null);
+
+                var telemetry = this.sentItems.Last() as DependencyTelemetry;
+
+                Assert.IsNotNull(telemetry);
+                Assert.AreEqual("EventHubProducerClient.Send", telemetry.Name);
+                Assert.AreEqual("amqps://eventHub.servicebus.windows.net/ | queueName", telemetry.Target);
+                Assert.AreEqual(string.Empty, telemetry.Data);
+                Assert.AreEqual(string.Empty, telemetry.ResultCode);
+                Assert.AreEqual("Azure Event Hubs", telemetry.Type);
+                Assert.IsTrue(telemetry.Success.Value);
+
+                Assert.IsNull(telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
+                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
             }
         }
 
@@ -135,7 +423,6 @@
             if (listener.IsEnabled(activityName))
             {
                 activity = new Activity(activityName);
-                activity.AddTag("property", "eventhubname.servicebus.windows.net");
 
                 if (Activity.Current == null && parentId != null)
                 {
@@ -158,6 +445,20 @@
             // no new telemetry items were added
             Assert.AreEqual(itemCountBefore, this.sentItems.Count);
             return null;
+        }
+
+        private class PayloadWithLinks
+        {
+            public IEnumerable<Activity> Links { get; set; }
+        }
+
+        private class ApplicationInsightsLink
+        {
+            [JsonProperty("operation_Id")]
+            public string OperationId { get; set; }
+
+            [JsonProperty("id")]
+            public string Id { get; set; }
         }
     }
 }

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -240,12 +240,12 @@
         [TestMethod]
         public void AzureClientSpansAreCollectedForHttp()
         {
-            using (var listener = new DiagnosticListener("Azure.Core"))
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
             using (var module = new DependencyTrackingTelemetryModule())
             {
                 module.Initialize(this.configuration);
 
-                Activity httpActivity = new Activity("Azure.Core.Http.Request")
+                Activity httpActivity = new Activity("Azure.SomeClient.Http.Request")
                     .AddTag("http.method", "PATCH")
                     .AddTag("http.url", "http://host:8080/path?query#fragment")
                     .AddTag("requestId", "client-request-id");
@@ -279,12 +279,12 @@
         [TestMethod]
         public void AzureClientSpansAreCollectedForHttpNotSuccessResponse()
         {
-            using (var listener = new DiagnosticListener("Azure.Core"))
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
             using (var module = new DependencyTrackingTelemetryModule())
             {
                 module.Initialize(this.configuration);
 
-                Activity httpActivity = new Activity("Azure.Core.Http.Request")
+                Activity httpActivity = new Activity("Azure.SomeClient.Http.Request")
                     .AddTag("http.method", "PATCH")
                     .AddTag("http.url", "http://host/path?query#fragment");
 
@@ -313,13 +313,13 @@
         [TestMethod]
         public void AzureClientSpansAreCollectedForHttpException()
         {
-            using (var listener = new DiagnosticListener("Azure.Core"))
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
             using (var module = new DependencyTrackingTelemetryModule())
             {
                 module.Initialize(this.configuration);
 
                 var exception = new InvalidOperationException();
-                Activity httpActivity = new Activity("Azure.Core.Http.Request")
+                Activity httpActivity = new Activity("Azure.SomeClient.Http.Request")
                     .AddTag("http.method", "PATCH")
                     .AddTag("http.url", "http://host/path?query#fragment");
 
@@ -348,25 +348,26 @@
         [TestMethod]
         public void AzureClientSpansAreCollectedForEventHubs()
         {
-            using (var listener = new DiagnosticListener("Azure.Messaging.EventHubs"))
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
             using (var module = new DependencyTrackingTelemetryModule())
             {
                 module.Initialize(this.configuration);
 
                 var exception = new InvalidOperationException();
-                Activity sendActivity = new Activity("Azure.Messaging.EventHubs.EventHubProducerClient.Send")
+                Activity sendActivity = new Activity("Azure.SomeClient.Send")
                     .AddTag("peer.address", "amqps://eventHub.servicebus.windows.net/")
                     .AddTag("message_bus.destination", "queueName")
-                    .AddTag("kind", "producer");
+                    .AddTag("kind", "producer")
+                    .AddTag("component", "eventhubs");
 
                 listener.StartActivity(sendActivity, null);
-                listener.Write("Azure.Messaging.EventHubs.EventHubProducerClient.Send.Exception", exception);
+                listener.Write("Azure.SomeClient.Send.Exception", exception);
                 listener.StopActivity(sendActivity, null);
 
                 var telemetry = this.sentItems.Last() as DependencyTelemetry;
 
                 Assert.IsNotNull(telemetry);
-                Assert.AreEqual("EventHubProducerClient.Send", telemetry.Name);
+                Assert.AreEqual("SomeClient.Send", telemetry.Name);
                 Assert.AreEqual("amqps://eventHub.servicebus.windows.net/ | queueName", telemetry.Target);
                 Assert.AreEqual(string.Empty, telemetry.Data);
                 Assert.AreEqual(string.Empty, telemetry.ResultCode);
@@ -382,15 +383,16 @@
         [TestMethod]
         public void AzureClientSpansAreCollectedForEventHubsException()
         {
-            using (var listener = new DiagnosticListener("Azure.Messaging.EventHubs"))
+            using (var listener = new DiagnosticListener("Azure.SomeClient"))
             using (var module = new DependencyTrackingTelemetryModule())
             {
                 module.Initialize(this.configuration);
 
-                Activity sendActivity = new Activity("Azure.Messaging.EventHubs.EventHubProducerClient.Send")
+                Activity sendActivity = new Activity("Azure.SomeClient.Send")
                     .AddTag("peer.address", "amqps://eventHub.servicebus.windows.net/")
                     .AddTag("message_bus.destination", "queueName")
-                    .AddTag("kind", "producer");
+                    .AddTag("kind", "producer")
+                    .AddTag("component", "eventhubs");
 
                 listener.StartActivity(sendActivity, null);
                 listener.StopActivity(sendActivity, null);
@@ -398,7 +400,7 @@
                 var telemetry = this.sentItems.Last() as DependencyTelemetry;
 
                 Assert.IsNotNull(telemetry);
-                Assert.AreEqual("EventHubProducerClient.Send", telemetry.Name);
+                Assert.AreEqual("SomeClient.Send", telemetry.Name);
                 Assert.AreEqual("amqps://eventHub.servicebus.windows.net/ | queueName", telemetry.Target);
                 Assert.AreEqual(string.Empty, telemetry.Data);
                 Assert.AreEqual(string.Empty, telemetry.ResultCode);

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/Operation/ObjectInstanceBasedOperationHolderTests.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/Operation/ObjectInstanceBasedOperationHolderTests.cs
@@ -13,14 +13,14 @@
     public class ObjectInstanceBasedOperationHolderTests
     {
         private Tuple<DependencyTelemetry, bool> telemetryTuple;
-        private ObjectInstanceBasedOperationHolder objectInstanceBasedOperationHolder;
+        private ObjectInstanceBasedOperationHolder<DependencyTelemetry> objectInstanceBasedOperationHolder;
         private WebRequest webRequest;
 
         [TestInitialize]
         public void TestInitialize()
         {
             this.telemetryTuple = new Tuple<DependencyTelemetry, bool>(new DependencyTelemetry(), true);
-            this.objectInstanceBasedOperationHolder = new ObjectInstanceBasedOperationHolder();
+            this.objectInstanceBasedOperationHolder = new ObjectInstanceBasedOperationHolder<DependencyTelemetry>();
             this.webRequest = WebRequest.Create(new Uri("http://bing.com"));
         }
 

--- a/WEB/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
+++ b/WEB/Src/DependencyCollector/Shared/DependencyTrackingTelemetryModule.cs
@@ -148,7 +148,7 @@
 
                             this.sqlClientDiagnosticSourceListener = new SqlClientDiagnosticSourceListener(configuration);
 
-                            if (EnableAzureSdkTelemetryListener)
+                            if (this.EnableAzureSdkTelemetryListener)
                             {
                                 this.azureSdkDiagnosticListener = new AzureSdkDiagnosticListenerSubscriber(configuration);
                                 this.azureSdkDiagnosticListener.Subscribe();

--- a/WEB/Src/DependencyCollector/Shared/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
+    using System;
     using System.Diagnostics;
     using Microsoft.ApplicationInsights.Extensibility;
 
@@ -13,7 +14,7 @@
 
         internal override bool IsSourceEnabled(DiagnosticListener diagnosticListener)
         {
-            return diagnosticListener.Name.StartsWith(DiagnosticListenerName);
+            return diagnosticListener.Name.StartsWith(DiagnosticListenerName, StringComparison.Ordinal);
         }
 
         internal override bool IsActivityEnabled(string evnt, object context)

--- a/WEB/Src/DependencyCollector/Shared/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -19,7 +19,7 @@
 
         // fetchers must not be reused between sources
         // fetcher is created per AzureSdkDiagnosticsEventHandler and AzureSdkDiagnosticsEventHandler is created per DiagnosticSource
-        private readonly PropertyFetcher LinksPropertyFetcher = new PropertyFetcher("Links");
+        private readonly PropertyFetcher linksPropertyFetcher = new PropertyFetcher("Links");
 
         public AzureSdkDiagnosticsEventHandler(TelemetryConfiguration configuration) : base(configuration)
         {
@@ -35,7 +35,7 @@
             try
             {
                 var currentActivity = Activity.Current;
-                if (evnt.Key.EndsWith(".Start"))
+                if (evnt.Key.EndsWith(".Start", StringComparison.Ordinal))
                 {
                     OperationTelemetry telemetry = null;
                     if (diagnosticListener.Name == "Azure.Core")
@@ -61,6 +61,7 @@
                                         dependencyType = RemoteDependencyConstants.AzureEventHubs;
                                     }
                                 }
+
                                 break;
                             }
                         }
@@ -70,7 +71,7 @@
                             telemetry = new DependencyTelemetry { Type = dependencyType };
                         }
 
-                        if (this.LinksPropertyFetcher.Fetch(evnt.Value) is IEnumerable<Activity> activityLinks)
+                        if (this.linksPropertyFetcher.Fetch(evnt.Value) is IEnumerable<Activity> activityLinks)
                         {
                             this.PopulateLinks(activityLinks, telemetry);
                         }
@@ -78,7 +79,7 @@
 
                     this.operationHolder.Store(currentActivity, Tuple.Create(telemetry, /* isCustomCreated: */ false));
                 }
-                if (evnt.Key.EndsWith(".Stop"))
+                else if (evnt.Key.EndsWith(".Stop", StringComparison.Ordinal))
                 {
                     var telemetry = this.operationHolder.Get(currentActivity).Item1;
                     this.SetCommonProperties(evnt.Key, evnt.Value, currentActivity, telemetry);
@@ -101,7 +102,7 @@
 
                     this.TelemetryClient.Track(telemetry);
                 }
-                else if (evnt.Key.EndsWith(".Exception"))
+                else if (evnt.Key.EndsWith(".Exception", StringComparison.Ordinal))
                 {
                     Exception ex = evnt.Value as Exception;
 

--- a/WEB/Src/DependencyCollector/Shared/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-
-namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
+    using System.Text;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -13,9 +15,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
     internal class AzureSdkDiagnosticsEventHandler : DiagnosticsEventHandlerBase
     {
-        private readonly ObjectInstanceBasedOperationHolder operationHolder = new ObjectInstanceBasedOperationHolder();
+        private readonly ObjectInstanceBasedOperationHolder<OperationTelemetry> operationHolder = new ObjectInstanceBasedOperationHolder<OperationTelemetry>();
 
-        public AzureSdkDiagnosticsEventHandler(TelemetryConfiguration configuration):base(configuration)
+        // fetchers must not be reused between sources
+        // fetcher is created per AzureSdkDiagnosticsEventHandler and AzureSdkDiagnosticsEventHandler is created per DiagnosticSource
+        private readonly PropertyFetcher LinksPropertyFetcher = new PropertyFetcher("Links");
+
+        public AzureSdkDiagnosticsEventHandler(TelemetryConfiguration configuration) : base(configuration)
         {
         }
 
@@ -31,30 +37,79 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                 var currentActivity = Activity.Current;
                 if (evnt.Key.EndsWith(".Start"))
                 {
-                    var telemetry = new DependencyTelemetry();
-                    
-                    SetCommonProperties(evnt.Key, evnt.Value, currentActivity, telemetry);
+                    OperationTelemetry telemetry = null;
+                    if (diagnosticListener.Name == "Azure.Core")
+                    {
+                        telemetry = new DependencyTelemetry { Type = RemoteDependencyConstants.HTTP };
+                    }
+                    else
+                    {
+                        string dependencyType = RemoteDependencyConstants.InProc;
+                        foreach (var tag in currentActivity.Tags)
+                        {
+                            if (tag.Key == "kind")
+                            {
+                                if (tag.Value == "server" || tag.Value == "consumer")
+                                {
+                                    telemetry = new RequestTelemetry();
+                                }
+                                else if (tag.Value != "internal")
+                                {
+                                    dependencyType = string.Empty;
+                                    if (diagnosticListener.Name == "Azure.Messaging.EventHubs")
+                                    {
+                                        dependencyType = RemoteDependencyConstants.AzureEventHubs;
+                                    }
+                                }
+                                break;
+                            }
+                        }
 
-                    telemetry.Properties["DiagnosticSource"] = diagnosticListener.Name;
-                    telemetry.Properties["Activity"] = currentActivity.OperationName;
+                        if (telemetry == null)
+                        {
+                            telemetry = new DependencyTelemetry { Type = dependencyType };
+                        }
 
-                    operationHolder.Store(currentActivity, Tuple.Create(telemetry, /* isCustomCreated: */ false));
+                        if (this.LinksPropertyFetcher.Fetch(evnt.Value) is IEnumerable<Activity> activityLinks)
+                        {
+                            this.PopulateLinks(activityLinks, telemetry);
+                        }
+                    }
+
+                    this.operationHolder.Store(currentActivity, Tuple.Create(telemetry, /* isCustomCreated: */ false));
                 }
                 if (evnt.Key.EndsWith(".Stop"))
                 {
-                    var telemetry = operationHolder.Get(currentActivity).Item1;
-                    telemetry.Duration = currentActivity.Duration;
-                    TelemetryClient.TrackDependency(telemetry);
+                    var telemetry = this.operationHolder.Get(currentActivity).Item1;
+                    this.SetCommonProperties(evnt.Key, evnt.Value, currentActivity, telemetry);
+
+                    if (telemetry is DependencyTelemetry dependency)
+                    {
+                        if (dependency.Type == RemoteDependencyConstants.HTTP)
+                        {
+                            this.SetHttpProperties(currentActivity, dependency);
+                            if (evnt.Value != null)
+                            {
+                                dependency.SetOperationDetail(evnt.Value.GetType().FullName, evnt.Value);
+                            }
+                        }
+                        else if (dependency.Type == RemoteDependencyConstants.AzureEventHubs)
+                        {
+                            this.SetEventHubsProperties(currentActivity, dependency);
+                        }
+                    }
+
+                    this.TelemetryClient.Track(telemetry);
                 }
                 else if (evnt.Key.EndsWith(".Exception"))
                 {
                     Exception ex = evnt.Value as Exception;
 
-                    var telemetry = operationHolder.Get(currentActivity);
+                    var telemetry = this.operationHolder.Get(currentActivity);
                     telemetry.Item1.Success = false;
                     if (ex != null)
                     {
-                        telemetry.Item1.Data = ex.ToInvariantString();
+                        telemetry.Item1.Properties[RemoteDependencyConstants.DependencyErrorPropertyKey] = ex.ToInvariantString();
                     }
                 }
             }
@@ -62,6 +117,10 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             {
                 DependencyCollectorEventSource.Log.TelemetryDiagnosticSourceCallbackException(evnt.Key, ex.ToInvariantString());
             }
+        }
+
+        protected override void PopulateTags(Activity activity, OperationTelemetry telemetry)
+        {
         }
 
         protected override string GetOperationName(string eventName, object eventPayload, Activity activity)
@@ -88,6 +147,119 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         protected override bool IsOperationSuccessful(string eventName, object eventPayload, Activity activity)
         {
             return true;
+        }
+
+        private void SetHttpProperties(Activity activity, DependencyTelemetry dependency)
+        {
+            string method = null;
+            string url = null;
+            string status = null;
+
+            foreach (var tag in activity.Tags)
+            {
+                if (tag.Key == "http.url")
+                {
+                    url = tag.Value;
+                }
+                else if (tag.Key == "http.method")
+                {
+                    method = tag.Value;
+                }
+                else if (tag.Key == "requestId")
+                {
+                    dependency.Properties["ClientRequestId"] = tag.Value;
+                }
+                else if (tag.Key == "serviceRequestId")
+                {
+                    dependency.Properties["ServerRequestId"] = tag.Value;
+                }
+                else if (tag.Key == "http.status_code")
+                {
+                    status = tag.Value;
+                }
+            }
+
+            // TODO: could be optimized to avoid full URI parsing and allocation
+            if (url == null || !Uri.TryCreate(url, UriKind.Absolute, out var parsedUrl))
+            {
+                // TODO log error: something is wrong
+                return;
+            }
+
+            dependency.Name = string.Concat(method, " ", parsedUrl.AbsolutePath);
+            dependency.Type = RemoteDependencyConstants.HTTP;
+            dependency.Data = url;
+            dependency.Target = DependencyTargetNameHelper.GetDependencyTargetName(parsedUrl);
+            dependency.ResultCode = status;
+
+            if (int.TryParse(status, out var statusCode))
+            {
+                dependency.Success = (statusCode > 0) && (statusCode < 400);
+            }
+        }
+
+        private void SetEventHubsProperties(Activity activity, DependencyTelemetry dependency)
+        {
+            string endpoint = null;
+            string queueName = null;
+
+            foreach (var tag in activity.Tags)
+            {
+                if (tag.Key == "peer.address")
+                {
+                    endpoint = tag.Value;
+                }
+                else if (tag.Key == "message_bus.destination")
+                {
+                    queueName = tag.Value;
+                }
+            }
+
+            // Target uniquely identifies the resource, we use both: queueName and endpoint 
+            // with schema used for SQL-dependencies
+            dependency.Target = string.Concat(endpoint, " | ", queueName);
+        }
+
+        private void PopulateLinks(IEnumerable<Activity> links, OperationTelemetry telemetry)
+        {
+            if (links.Any())
+            {
+                var linksJson = new StringBuilder();
+                linksJson.Append('[');
+                foreach (var link in links)
+                {
+                    var linkTraceId = link.TraceId.ToHexString();
+
+                    // avoiding json serializers for now because of extra dependency.
+                    // serialization is trivial and looks like `links` property with json blob
+                    // [{"operation_Id":"5eca8b153632494ba00f619d6877b134","id":"d4c1279b6e7b7c47"},
+                    //  {"operation_Id":"ff28988d0776b44f9ca93352da126047","id":"bf4fa4855d161141"}]
+                    linksJson
+                        .Append('{')
+                        .Append("\"operation_Id\":")
+                        .Append('\"')
+                        .Append(linkTraceId)
+                        .Append('\"')
+                        .Append(',');
+                    linksJson
+                        .Append("\"id\":")
+                        .Append('\"')
+                        .Append(link.ParentSpanId.ToHexString())
+                        .Append('\"');
+
+                    // we explicitly ignore sampling flag, tracestate and attributes at this point.
+                    linksJson.Append("},");
+                }
+
+                if (linksJson.Length > 0)
+                {
+                    // trim trailing comma - json does not support it
+                    linksJson.Remove(linksJson.Length - 1, 1);
+                }
+
+                linksJson.Append("]");
+                telemetry.Properties["_MS.links"] = linksJson.ToString();
+            }
         }
     }
 }

--- a/WEB/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -493,6 +493,16 @@
             this.WriteEvent(47, httpInstrumentationVersion, httpClientMajorVersion, httpClientMinorVersion, infoVersion, this.applicationNameProvider.Name);
         }
 
+        [Event(
+            48,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "Http request is already instrumented.",
+            Level = EventLevel.Verbose)]
+        public void HttpRequestAlreadyInstrumented(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(48, this.applicationNameProvider.Name);
+        }
+
         /// <summary>
         /// Keywords for the <see cref="DependencyCollectorEventSource"/>.
         /// </summary>

--- a/WEB/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/DependencyCollectorEventSource.cs
@@ -503,6 +503,16 @@
             this.WriteEvent(48, this.applicationNameProvider.Name);
         }
 
+        [Event(
+            49,
+            Keywords = Keywords.RddEventKeywords,
+            Message = "Failed to parse Url '{0}'",
+            Level = EventLevel.Warning)]
+        public void FailedToParseUrl(string url, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(49, url, this.applicationNameProvider.Name);
+        }
+
         /// <summary>
         /// Keywords for the <see cref="DependencyCollectorEventSource"/>.
         /// </summary>

--- a/WEB/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/DependencyTableStore.cs
@@ -1,7 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
-    using System.Threading;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
 
     internal class DependencyTableStore : IDisposable
@@ -9,8 +9,8 @@
         internal static bool IsDesktopHttpDiagnosticSourceActivated = false;
         internal CacheBasedOperationHolder WebRequestCacheHolder;
         internal CacheBasedOperationHolder SqlRequestCacheHolder;
-        internal ObjectInstanceBasedOperationHolder WebRequestConditionalHolder;
-        internal ObjectInstanceBasedOperationHolder SqlRequestConditionalHolder;
+        internal ObjectInstanceBasedOperationHolder<DependencyTelemetry> WebRequestConditionalHolder;
+        internal ObjectInstanceBasedOperationHolder<DependencyTelemetry> SqlRequestConditionalHolder;
 
         internal bool IsProfilerActivated = false;
 
@@ -20,8 +20,8 @@
         {
             this.WebRequestCacheHolder = new CacheBasedOperationHolder("aisdkwebrequests", 100 * 1000);
             this.SqlRequestCacheHolder = new CacheBasedOperationHolder("aisdksqlrequests", 100 * 1000);
-            this.WebRequestConditionalHolder = new ObjectInstanceBasedOperationHolder();
-            this.SqlRequestConditionalHolder = new ObjectInstanceBasedOperationHolder();
+            this.WebRequestConditionalHolder = new ObjectInstanceBasedOperationHolder<DependencyTelemetry>();
+            this.SqlRequestConditionalHolder = new ObjectInstanceBasedOperationHolder<DependencyTelemetry>();
         }
 
         internal static DependencyTableStore Instance

--- a/WEB/Src/DependencyCollector/Shared/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-
-namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers
 {
     using System;
     using System.Collections.Concurrent;

--- a/WEB/Src/DependencyCollector/Shared/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers
+﻿using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.EventHandlers
 {
     using System;
     using System.Collections.Concurrent;
@@ -77,13 +79,7 @@
                 telemetry.Context.Operation.ParentId = activity.ParentId;
             }
 
-            foreach (var item in activity.Tags)
-            {
-                if (!telemetry.Properties.ContainsKey(item.Key))
-                {
-                    telemetry.Properties[item.Key] = item.Value;
-                }
-            }
+            this.PopulateTags(activity, telemetry);
 
             foreach (var item in activity.Baggage)
             {
@@ -93,7 +89,21 @@
                 }
             }
 
-            telemetry.Success = this.IsOperationSuccessful(eventName, eventPayload, activity);
+            if (!telemetry.Success.HasValue)
+            {
+                telemetry.Success = this.IsOperationSuccessful(eventName, eventPayload, activity);
+            }
+        }
+
+        protected virtual void PopulateTags(Activity activity, OperationTelemetry telemetry)
+        {
+            foreach (var item in activity.Tags)
+            {
+                if (!telemetry.Properties.ContainsKey(item.Key))
+                {
+                    telemetry.Properties[item.Key] = item.Value;
+                }
+            }
         }
 
         protected virtual string GetOperationName(string eventName, object eventPayload, Activity activity)

--- a/WEB/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -120,8 +120,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 
                 if (webRequest.Headers[W3C.W3CConstants.TraceParentHeader] != null && Activity.DefaultIdFormat == ActivityIdFormat.W3C)
                 {
-                    // TODO comment and log
-                    // DependencyCollectorEventSource.Log.CurrentActivityIsNull(HttpOutStartEventName);
+                    DependencyCollectorEventSource.Log.HttpRequestAlreadyInstrumented();
                     return null;
                 }
 

--- a/WEB/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -118,6 +118,13 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     return null;
                 }
 
+                if (webRequest.Headers[W3C.W3CConstants.TraceParentHeader] != null && Activity.DefaultIdFormat == ActivityIdFormat.W3C)
+                {
+                    // TODO comment and log
+                    // DependencyCollectorEventSource.Log.CurrentActivityIsNull(HttpOutStartEventName);
+                    return null;
+                }
+
                 // If the object already exists, don't add again. This happens because either GetResponse or GetRequestStream could
                 // be the starting point for the outbound call.
                 DependencyTelemetry telemetry = null;

--- a/WEB/Src/DependencyCollector/Shared/Implementation/Operation/ObjectInstanceBasedOperationHolder.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/Operation/ObjectInstanceBasedOperationHolder.cs
@@ -1,22 +1,22 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation
 {
     using System;
-    using System.Collections.Generic;
     using System.Runtime.CompilerServices;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
-    internal class ObjectInstanceBasedOperationHolder
+    internal class ObjectInstanceBasedOperationHolder<TTelemetry> where TTelemetry : OperationTelemetry
     {
-        private ConditionalWeakTable<object, Tuple<DependencyTelemetry, bool>> weakTableForCorrelation = new ConditionalWeakTable<object, Tuple<DependencyTelemetry, bool>>();
+        private ConditionalWeakTable<object, Tuple<TTelemetry, bool>> weakTableForCorrelation = new ConditionalWeakTable<object, Tuple<TTelemetry, bool>>();
 
-        public Tuple<DependencyTelemetry, bool> Get(object holderInstance)
+        public Tuple<TTelemetry, bool> Get(object holderInstance)
         {
             if (holderInstance == null)
             {
                 throw new ArgumentNullException(nameof(holderInstance));
             }
 
-            Tuple<DependencyTelemetry, bool> result = null;
+            Tuple<TTelemetry, bool> result = null;
             if (!this.weakTableForCorrelation.TryGetValue(holderInstance, out result))
             {
                 result = null;
@@ -35,7 +35,7 @@
             return this.weakTableForCorrelation.Remove(holderInstance);
         }
 
-        public void Store(object holderInstance, Tuple<DependencyTelemetry, bool> telemetryTuple)
+        public void Store(object holderInstance, Tuple<TTelemetry, bool> telemetryTuple)
         {
             if (holderInstance == null)
             {

--- a/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerHttpProcessing.cs
@@ -7,7 +7,6 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
     /// <summary>
     /// Concrete class with all processing logic to generate RDD data from the callbacks
@@ -15,12 +14,12 @@
     /// </summary>
     internal sealed class ProfilerHttpProcessing : HttpProcessing
     {
-        internal ObjectInstanceBasedOperationHolder TelemetryTable;
+        internal ObjectInstanceBasedOperationHolder<DependencyTelemetry> TelemetryTable;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilerHttpProcessing"/> class.
         /// </summary>
-        public ProfilerHttpProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, bool injectLegacyHeaders, bool injectW3CHeaders)
+        public ProfilerHttpProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder<DependencyTelemetry> telemetryTupleHolder, bool setCorrelationHeaders, ICollection<string> correlationDomainExclusionList, bool injectLegacyHeaders, bool injectW3CHeaders)
             : base(configuration, SdkVersionUtils.GetSdkVersion("rdd" + RddSource.Profiler + ":"), agentVersion, setCorrelationHeaders, correlationDomainExclusionList, injectLegacyHeaders, injectW3CHeaders)
         {
             if (telemetryTupleHolder == null)

--- a/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerSqlCommandProcessing.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerSqlCommandProcessing.cs
@@ -2,6 +2,7 @@
 {
     using System.Data;
     using System.Data.SqlClient;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
 
@@ -13,7 +14,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilerSqlCommandProcessing"/> class.
         /// </summary>
-        internal ProfilerSqlCommandProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder telemetryTupleHolder)
+        internal ProfilerSqlCommandProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder<DependencyTelemetry> telemetryTupleHolder)
             : base(configuration, agentVersion, telemetryTupleHolder)
         {            
         }

--- a/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerSqlConnectionProcessing.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerSqlConnectionProcessing.cs
@@ -1,8 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
-    using System;
     using System.Data.SqlClient;
-    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
 
@@ -19,7 +18,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilerSqlConnectionProcessing"/> class.
         /// </summary>
-        internal ProfilerSqlConnectionProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder telemetryTupleHolder)
+        internal ProfilerSqlConnectionProcessing(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder<DependencyTelemetry> telemetryTupleHolder)
             : base(configuration, agentVersion, telemetryTupleHolder)
         {
         }              

--- a/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerSqlProcessingBase.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/ProfilerSqlProcessingBase.cs
@@ -16,13 +16,13 @@
     /// </summary>
     internal abstract class ProfilerSqlProcessingBase
     {
-        internal ObjectInstanceBasedOperationHolder TelemetryTable;
+        internal ObjectInstanceBasedOperationHolder<DependencyTelemetry> TelemetryTable;
         private readonly TelemetryClient telemetryClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProfilerSqlProcessingBase"/> class.
         /// </summary>
-        internal ProfilerSqlProcessingBase(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder telemetryTupleHolder)
+        internal ProfilerSqlProcessingBase(TelemetryConfiguration configuration, string agentVersion, ObjectInstanceBasedOperationHolder<DependencyTelemetry> telemetryTupleHolder)
         {
             if (configuration == null)
             {

--- a/WEB/Src/DependencyCollector/Shared/Implementation/RemoteDependencyConstants.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/RemoteDependencyConstants.cs
@@ -14,6 +14,7 @@
         public const string AzureServiceBus = "Azure Service Bus";
         public const string AzureIotHub = "Azure IoT Hub";
         public const string AzureSearch = "Azure Search";
+        public const string InProc = "InProc";
 
         public const string WcfService = "WCF Service";
         public const string WebService = "Web Service";
@@ -23,5 +24,7 @@
         public const string HttpResponseHeadersOperationDetailName = "HttpResponseHeaders";
 
         public const string SqlCommandOperationDetailName = "SqlCommand";
+
+        public const string DependencyErrorPropertyKey = "Error";
     }
 }

--- a/WEB/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
@@ -1,5 +1,3 @@
-using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
-
 namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlClientDiagnostics
 {
     using System;
@@ -9,6 +7,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;

--- a/WEB/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
@@ -1,3 +1,5 @@
+using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
+
 namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlClientDiagnostics
 {
     using System;
@@ -7,7 +9,6 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
 
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.DependencyCollector.Implementation.Operation;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
@@ -71,7 +72,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
         private readonly TelemetryClient client;
         private readonly SqlClientDiagnosticSourceSubscriber subscriber;
 
-        private readonly ObjectInstanceBasedOperationHolder operationHolder = new ObjectInstanceBasedOperationHolder();
+        private readonly ObjectInstanceBasedOperationHolder<DependencyTelemetry> operationHolder = new ObjectInstanceBasedOperationHolder<DependencyTelemetry>();
 
         public SqlClientDiagnosticSourceListener(TelemetryConfiguration configuration)
         {


### PR DESCRIPTION
This is follow up on this: https://github.com/microsoft/ApplicationInsights-dotnet/pull/1300#issuecomment-553998634

This needs a bit more work
- [x] Tests for existing HTTP collectors (that they back off when traceparent header is present). I'll do it tomorrow
- [x]  Some TODO items with extra logging (will do)
- [x] Can we make `AzureSdkDiagnosticsEventHandler` code nicer? E.g. we can introduce special handlers for AzureCore and EventHubs since they require special treatment. Can you have a look?

How it looks now

Transaction viewer

![image](https://user-images.githubusercontent.com/2347409/69209489-45fdde80-0b0c-11ea-92c7-0d84094e4f7a.png)

"Upstream operation" thing is a known bug for links - UX folks are fixing it


App map
![image](https://user-images.githubusercontent.com/2347409/69209563-83fb0280-0b0c-11ea-84eb-e5799171de12.png)







